### PR TITLE
open_tree: Note EPERM

### DIFF
--- a/open_tree.md
+++ b/open_tree.md
@@ -118,6 +118,10 @@ returned, and *errno* is set appropriately.
 Search permission is denied for one of the directories in the path
 prefix of *pathname*. (See also **path_resolution**(7).)
 
+**EPERM**
+The **OPEN_TREE_CLONE** flag was specified and the caller does not
+have the required privileges.
+
 **EBADF**  
 *dirfd* is not a valid open file descriptor.
 


### PR DESCRIPTION
This came up in https://github.com/containers/bootc/pull/983 and it's actually *really* cool honestly that one can do a non-cloning (detached) `open_tree` without privileges. Let's note that implicitly by documenting that this can return `EPERM`.