### PR TITLE
open_tree: fix kernel version

### DIFF
--- a/open_tree.md
+++ b/open_tree.md
@@ -152,7 +152,7 @@ file other than a directory.
 
 # VERSIONS
 
-**open_tree**() was added to Linux in kernel 4.18.
+**open_tree**() was added to Linux in kernel 5.2.
 
 # CONFORMING TO
 

--- a/pidfd_open.md
+++ b/pidfd_open.md
@@ -32,7 +32,7 @@ close-on-exec flag is set on the file descriptor.
 ## The *flags* mask
 
 The *flags* argument either has the value 0, or contains the following
-flag:
+flags:
 
 **PIDFD_NONBLOCK** (since Linux 5.10)  
 Return a nonblocking file descriptor. If the process referred to by the


### PR DESCRIPTION
The open_tree syscall was actually added to Linux v5.2, here's the first commit mentioning it:

	commit a07b20004793
	Author: Al Viro <viro@zeniv.linux.org.uk>
	Date:   Mon Nov 5 17:40:30 2018 +0000

	vfs: syscall: Add open_tree(2) to reference or clone a mount

Fix the man page accordingly.

Reported-by: @cyphar