### PR TITLE
pidfd_open: nit

### DIFF
--- a/pidfd_open.md
+++ b/pidfd_open.md
@@ -32,7 +32,7 @@ close-on-exec flag is set on the file descriptor.
 ## The *flags* mask
 
 The *flags* argument either has the value 0, or contains the following
-flag:
+flags:
 
 **PIDFD_NONBLOCK** (since Linux 5.10)  
 Return a nonblocking file descriptor. If the process referred to by the


### PR DESCRIPTION
There are multiple flags now, thus plural.

Fixes: 1d9979f ("pidfd_open(2): add PIDFD_THREAD")